### PR TITLE
Add variant-based board geometry

### DIFF
--- a/src/bit.cpp
+++ b/src/bit.cpp
@@ -14,9 +14,11 @@
 static bit_t Bit_File[10];
 static bit_t Bit_Rank[10];
 
-static bit_t King_One[Square_Size];
-static bit_t King_Almost[Square_Size];
-static bit_t King_All[Square_Size];
+bit_t Bit_Squares;
+
+static bit_t King_One[Square_Size_Max];
+static bit_t King_Almost[Square_Size_Max];
+static bit_t King_All[Square_Size_Max];
 
 static bit_t Beyond[64][64];
 static bit_t Between[64][64];
@@ -39,13 +41,22 @@ void bit_init() {
 
    // board lines
 
-   for (int i = 0; i < 5; i++) {
+   for (int i = 0; i < 10; i++) {
+      Bit_File[i] = 0;
+      Bit_Rank[i] = 0;
+   }
 
-      Bit_File[i * 2 + 0] = bit_5(i + 11, 11);
-      Bit_File[i * 2 + 1] = bit_5(i +  6, 11);
+   for (int i = 0; i < Square_Count; i++) {
+      int sq = square_from_50(i);
+      int fl = square_file(sq);
+      int rk = square_rank(sq);
+      if (fl >= 0 && fl < 10) bit_set(Bit_File[fl], sq);
+      if (rk >= 0 && rk < 10) bit_set(Bit_Rank[rk], sq);
+   }
 
-      Bit_Rank[i * 2 + 0] = bit_5(i * 11 +  6, 1);
-      Bit_Rank[i * 2 + 1] = bit_5(i * 11 + 11, 1);
+   Bit_Squares = 0;
+   for (int i = 0; i < Square_Count; i++) {
+      bit_set(Bit_Squares, square_from_50(i));
    }
 
    // king attacks
@@ -58,7 +69,7 @@ void bit_init() {
       }
    }
 
-   for (int i = 0; i < 50; i++) {
+   for (int i = 0; i < Square_Count; i++) {
 
       int from = square_from_50(i);
 

--- a/src/bit.h
+++ b/src/bit.h
@@ -16,7 +16,7 @@ typedef uint64 bit_t;
 
 // constants
 
-const bit_t Bit_Squares = U64(0x0FFDFFBFF7FEFFC0); // legal squares
+extern bit_t Bit_Squares; // legal squares, set per variant
 
 // functions
 

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -17,6 +17,7 @@
 #include "move.h"
 #include "move_gen.h"
 #include "pos.h"
+#include "var.h"
 
 // constants
 
@@ -46,9 +47,11 @@ static int piece_trit (int pc);
 
 void board_init() {
 
+   pos_init_geometry();
+
    for (int pc = 0; pc < Piece_Size; pc++) {
 
-      for (int i = 0; i < 50; i++) {
+      for (int i = 0; i < Square_Count; i++) {
 
          int sq = square_from_50(i);
 
@@ -72,7 +75,7 @@ Board::Board() {
 
 void Board::init() {
 
-   board_from_fen(*this, Start_FEN);
+   board_from_fen(*this, start_fen());
 }
 
 void Board::copy(const Board & bd) {
@@ -89,7 +92,7 @@ void Board::from_bit(int turn, bit_t wm, bit_t bm, bit_t wk, bit_t bk) {
 
    // p_pos.p_turn = 0;
 
-   for (int i = 0; i < 50; i++) {
+   for (int i = 0; i < Square_Count; i++) {
 
       int sq = square_from_50(i);
 
@@ -389,7 +392,8 @@ int board_pip(const Board & bd) {
 
    int pip = 0;
 
-   for (int rk = 0; rk < 10; rk++) {
+   int n = (var::Variant == var::Brazilian) ? 4 : 5;
+   for (int rk = 0; rk < 2 * n; rk++) {
 
       bit_t rank = bit_rank(rk);
 
@@ -408,8 +412,8 @@ int board_skew(const Board & bd, int sd) {
    bit_t bm = bd.bit_man(sd);
 
    int skew = 0;
-
-   for (int fl = 0; fl < 10; fl++) {
+   int n = (var::Variant == var::Brazilian) ? 4 : 5;
+   for (int fl = 0; fl < 2 * n; fl++) {
       skew += bit_count(bm & bit_file(fl)) * (fl * 2 - 9);
    }
 
@@ -427,13 +431,14 @@ double board_phase(const Board & bd) {
 
 void board_disp(const Board & bd) {
 
-   for (int y = 0; y < 10; y++) {
+   int n = (var::Variant == var::Brazilian) ? 4 : 5;
+   for (int y = 0; y < 2 * n; y++) {
 
       if (y % 2 == 0) std::printf("  ");
 
-      for (int x = 0; x < 5; x++) {
+      for (int x = 0; x < n; x++) {
 
-         int sq = square_from_50(y * 5 + x);
+         int sq = square_from_50(y * n + x);
 
          switch (bd.square(sq)) {
          case WM :    std::printf("O   "); break;
@@ -445,8 +450,8 @@ void board_disp(const Board & bd) {
          }
       }
 
-      for (int x = 0; x < 5; x++) {
-         std::printf("  %02d", y * 5 + x + 1);
+      for (int x = 0; x < n; x++) {
+         std::printf("  %02d", y * n + x + 1);
       }
 
       std::printf("\n");

--- a/src/board.h
+++ b/src/board.h
@@ -32,8 +32,8 @@ private :
    Pos p_pos;
 
    bit_t p_bit[Piece_Size];
-   int p_square[Square_Size];
-   int p_trit[Square_Size];
+   int p_square[Square_Size_Max];
+   int p_trit[Square_Size_Max];
 
    uint64 p_key;
    int p_pip;

--- a/src/fen.cpp
+++ b/src/fen.cpp
@@ -9,6 +9,7 @@
 #include "fen.h"
 #include "libmy.hpp"
 #include "pos.h"
+#include "var.h"
 #include "util.h"
 
 // prototypes
@@ -19,6 +20,10 @@ static void add_piece  (bit_t & bm, bit_t & bk, int sq, bool king);
 static std::string pos_pieces (const Pos & pos, int sd);
 
 static std::string run_string (int pc, int sq, int len);
+
+const std::string & start_fen() {
+   return (var::Variant == var::Brazilian) ? Start_FEN_Brazilian : Start_FEN_International;
+}
 
 // functions
 
@@ -127,7 +132,7 @@ static void add_pieces(bit_t & bm, bit_t & bk, Scanner_Number & scan) {
 
 static void add_piece(bit_t & bm, bit_t & bk, int sq, bool king) {
 
-   assert(sq >= 1 && sq <= 50);
+   assert(sq >= 1 && sq <= Square_Count);
 
    sq = square_from_50(sq - 1);
 
@@ -140,7 +145,7 @@ static void add_piece(bit_t & bm, bit_t & bk, int sq, bool king) {
 
 void pos_from_hub(Pos & pos, const std::string & s) {
 
-   if (s.size() != 51) throw Bad_Input();
+   if (s.size() != Square_Count + 1) throw Bad_Input();
 
    // turn
 
@@ -156,7 +161,7 @@ void pos_from_hub(Pos & pos, const std::string & s) {
 
    bit_t wm = 0, bm = 0, wk = 0, bk = 0;
 
-   for (int i = 0; i < 50; i++) {
+   for (int i = 0; i < Square_Count; i++) {
 
       int sq = square_from_50(i);
 
@@ -177,7 +182,7 @@ void pos_from_hub(Pos & pos, const std::string & s) {
 
 void pos_from_dxp(Pos & pos, const std::string & s) {
 
-   if (s.size() != 51) throw Bad_Input();
+   if (s.size() != Square_Count + 1) throw Bad_Input();
 
    // turn
 
@@ -193,7 +198,7 @@ void pos_from_dxp(Pos & pos, const std::string & s) {
 
    bit_t wm = 0, bm = 0, wk = 0, bk = 0;
 
-   for (int i = 0; i < 50; i++) {
+   for (int i = 0; i < Square_Count; i++) {
 
       int sq = square_from_50(i);
 
@@ -235,7 +240,7 @@ static std::string pos_pieces(const Pos & pos, int sd) {
    int run_sq = 0;
    int run_len = 0;
 
-   for (int i = 0; i < 50; i++) {
+   for (int i = 0; i < Square_Count; i++) {
 
       int sq = square_from_50(i);
       int pc = pos_square(pos, sq);
@@ -277,7 +282,7 @@ static std::string run_string(int pc, int sq, int len) {
 
    assert(piece_is_ok(pc));
    assert(len != 0);
-   assert(sq + len <= 50);
+   assert(sq + len <= Square_Count);
 
    std::string s;
 
@@ -304,7 +309,7 @@ std::string pos_hub(const Pos & pos) {
 
    s += (pos.turn() == White) ? "w" : "b";
 
-   for (int i = 0; i < 50; i++) {
+   for (int i = 0; i < Square_Count; i++) {
 
       int sq = square_from_50(i);
 
@@ -327,7 +332,7 @@ std::string pos_dxp(const Pos & pos) {
 
    s += (pos.turn() == White) ? "W" : "Z";
 
-   for (int i = 0; i < 50; i++) {
+   for (int i = 0; i < Square_Count; i++) {
 
       int sq = square_from_50(i);
 

--- a/src/fen.h
+++ b/src/fen.h
@@ -13,11 +13,12 @@
 class Pos;
 
 // constants
+const std::string Start_FEN_International = "W:W31-50:B1-20";
+const std::string Start_FEN_Brazilian    = "W:W21-32:B1-12";
+const std::string Start_Hub = "wbbbbbbbbbbbbbbbbbbbbeeeeeeeeeewwwwwwwwwwwwwwwwwww";
+const std::string Start_DXP = "Wzzzzzzzzzzzzzzzzzzzzeeeeeeeeeewwwwwwwwwwwwwwwwwww";
 
-const std::string Start_FEN = "W:W31-50:B1-20";
-const std::string Start_Hub = "wbbbbbbbbbbbbbbbbbbbbeeeeeeeeeewwwwwwwwwwwwwwwwwwww";
-const std::string Start_DXP = "Wzzzzzzzzzzzzzzzzzzzzeeeeeeeeeewwwwwwwwwwwwwwwwwwww";
-
+const std::string & start_fen();
 // functions
 
 extern void pos_from_fen (Pos & pos, const std::string & s);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -19,12 +19,12 @@
 
 void Game::clear() {
 
-   init(Start_FEN);
+   init(start_fen());
 }
 
 void Game::clear(int moves, double time, double inc) {
 
-   init(Start_FEN, moves, time, inc);
+   init(start_fen(), moves, time, inc);
 }
 
 void Game::init(const std::string & fen) {

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -33,7 +33,7 @@ void hash_init() {
    Turn_Key = Random_64[0];
 
    for (int pc = 0; pc < Piece_Size; pc++) {
-      for (int i = 0; i < 50; i++) {
+      for (int i = 0; i < Square_Count; i++) {
          int sq = square_from_50(i);
          Piece_Key[pc][sq] = Random_64[i * 4 + pc + 1];
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,7 @@ private :
    double p_time;
 
    move_t user_move ();
-   void   new_game  (const std::string & fen = Start_FEN);
+   void   new_game  (const std::string & fen = Start_FEN_International);
    void   go_to     (int pos);
 
 public :
@@ -329,7 +329,7 @@ void Terminal::loop() {
 
    const Board & bd = game.board();
 
-   new_game();
+   new_game(start_fen());
 
    while (true) {
 
@@ -462,7 +462,7 @@ move_t Terminal::user_move() {
 
    } else if (command == "n") {
 
-      new_game();
+      new_game(start_fen());
 
    } else if (command == "q") {
 

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -17,69 +17,58 @@
 #include "util.h"
 #include "var.h"
 
-// "constants"
+// geometry variables (initialised according to variant)
+int Square_Size = 66;
+int Square_Count = 50;
+int Square_From_50[50];
+int Square_To_50[Square_Size_Max];
+int Square_File[Square_Size_Max];
+int Square_Rank[Square_Size_Max];
+int Inc[Dir_Size];
 
-const int Square_From_50[50] = {
-      6,  7,  8,  9, 10,
-   11, 12, 13, 14, 15,
-     17, 18, 19, 20, 21,
-   22, 23, 24, 25, 26,
-     28, 29, 30, 31, 32,
-   33, 34, 35, 36, 37,
-     39, 40, 41, 42, 43,
-   44, 45, 46, 47, 48,
-     50, 51, 52, 53, 54,
-   55, 56, 57, 58, 59,
-};
+void pos_init_geometry() {
 
-const int Square_To_50[Square_Size] = {
-   -1, -1, -1, -1, -1, -1,
-      0,  1,  2,  3,  4,
-    5,  6,  7,  8,  9, -1,
-     10, 11, 12, 13, 14,
-   15, 16, 17, 18, 19, -1,
-     20, 21, 22, 23, 24,
-   25, 26, 27, 28, 29, -1,
-     30, 31, 32, 33, 34,
-   35, 36, 37, 38, 39, -1,
-     40, 41, 42, 43, 44,
-   45, 46, 47, 48, 49, -1,
-     -1, -1, -1, -1, -1,
-};
+   int n = (var::Variant == var::Brazilian) ? 4 : 5;
+   Square_Count = 2 * n * n;
+   int W = 2 * n + 1;
+   Square_Size = W * (n + 1);
 
-const int Square_File[Square_Size] = {
-   -1, -1, -1, -1, -1, -1,
-      1,  3,  5,  7,  9,
-    0,  2,  4,  6,  8, -1,
-      1,  3,  5,  7,  9,
-    0,  2,  4,  6,  8, -1,
-      1,  3,  5,  7,  9,
-    0,  2,  4,  6,  8, -1,
-      1,  3,  5,  7,  9,
-    0,  2,  4,  6,  8, -1,
-      1,  3,  5,  7,  9,
-    0,  2,  4,  6,  8, -1,
-     -1, -1, -1, -1, -1,
-};
+   // init arrays
+   for (int i = 0; i < 50; i++) Square_From_50[i] = -1;
+   for (int i = 0; i < Square_Size_Max; i++) {
+      Square_To_50[i] = -1;
+      Square_File[i] = -1;
+      Square_Rank[i] = -1;
+   }
 
-const int Square_Rank[Square_Size] = {
-   -1, -1, -1, -1, -1, -1,
-      0,  0,  0,  0,  0,
-    1,  1,  1,  1,  1, -1,
-      2,  2,  2,  2,  2,
-    3,  3,  3,  3,  3, -1,
-      4,  4,  4,  4,  4,
-    5,  5,  5,  5,  5, -1,
-      6,  6,  6,  6,  6,
-    7,  7,  7,  7,  7, -1,
-      8,  8,  8,  8,  8,
-    9,  9,  9,  9,  9, -1,
-     -1, -1, -1, -1, -1,
-};
+   int idx = 0;
+   for (int g = 0; g < n; g++) {
+      int rowA = n + 1 + g * W;
+      int rowB = rowA + n;
 
-const int Inc[Dir_Size] = {
-   NW_Inc, NE_Inc, SW_Inc, SE_Inc,
-};
+      for (int i = 0; i < n; i++) {
+         int sq = rowA + i;
+         Square_From_50[idx] = sq;
+         Square_To_50[sq] = idx;
+         Square_File[sq] = 2 * i + 1;
+         Square_Rank[sq] = 2 * g;
+         idx++;
+      }
+      for (int i = 0; i < n; i++) {
+         int sq = rowB + i;
+         Square_From_50[idx] = sq;
+         Square_To_50[sq] = idx;
+         Square_File[sq] = 2 * i;
+         Square_Rank[sq] = 2 * g + 1;
+         idx++;
+      }
+   }
+
+   Inc[NW] = -(n + 1);
+   Inc[NE] = -n;
+   Inc[SW] = +n;
+   Inc[SE] = +(n + 1);
+}
 
 // functions
 
@@ -93,7 +82,7 @@ bool string_is_square(const std::string & s) {
    if (!string_is_nat(s)) return false;
 
    int sq = ml::stoi(s);
-   return sq >= 1 && sq <= 50;
+   return sq >= 1 && sq <= Square_Count;
 }
 
 int square_from_string(const std::string & s) {
@@ -104,7 +93,7 @@ int square_from_string(const std::string & s) {
 
 int square_from_int(int sq) {
 
-   if (sq < 1 || sq > 50) throw Bad_Input();
+   if (sq < 1 || sq > Square_Count) throw Bad_Input();
    return square_from_50(sq - 1);
 }
 
@@ -115,7 +104,7 @@ void Pos::copy(const Pos & pos) {
 
 void Pos::init() {
 
-   pos_from_fen(*this, Start_FEN);
+   pos_from_fen(*this, start_fen());
 }
 
 void Pos::init(int turn, bit_t wp, bit_t bp, bit_t k) {

--- a/src/pos.h
+++ b/src/pos.h
@@ -14,19 +14,17 @@
 
 // constants
 
-const int Square_Size = 66;
+const int Square_Size_Max = 66;
+extern int Square_Size;
+extern int Square_Count;
 const int Dir_Size = 4;
 const int Side_Size = 2;
 const int Piece_Size = 4; // excludes empty #
 
 enum dir_t { NW, NE, SW, SE };
 
-enum inc_t {
-   NW_Inc = -6,
-   NE_Inc = -5,
-   SW_Inc = +5,
-   SE_Inc = +6
-};
+// increments (NW, NE, SW, SE) depend on the board variant
+extern int Inc[Dir_Size];
 
 enum side_t { White, Black };
 
@@ -34,13 +32,12 @@ enum piece_t { WM, WK, BM, BK, Empty, Frame };
 
 // "constants"
 
-extern const int Square_From_50[50];
-extern const int Square_To_50[Square_Size];
+extern int Square_From_50[50];
+extern int Square_To_50[Square_Size_Max];
 
-extern const int Square_File[Square_Size];
-extern const int Square_Rank[Square_Size];
-
-extern const int Inc[Dir_Size];
+extern int Square_File[Square_Size_Max];
+extern int Square_Rank[Square_Size_Max];
+extern int Inc[Dir_Size];
 
 // functions
 
@@ -89,6 +86,8 @@ extern std::string square_to_string   (int sq);
 extern bool        string_is_square   (const std::string & s);
 extern int         square_from_string (const std::string & s);
 extern int         square_from_int    (int sq);
+
+extern void pos_init_geometry();
 
 inline bool piece_is_ok     (int pc)         { return pc >= 0 && pc < Piece_Size; }
 inline int  piece_man       (int sd)         { return sd << 1; }

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -32,6 +32,7 @@ int  DXP_Time;
 int  DXP_Moves;
 bool DXP_Board;
 bool DXP_Search;
+variant_t Variant;
 
 static std::map<std::string, std::string> Var;
 
@@ -53,6 +54,7 @@ void init() {
    set("dxp-moves", "75");
    set("dxp-board", "false");
    set("dxp-search", "false");
+   set("variant", "international");
 
    update();
 }
@@ -108,6 +110,16 @@ void update() {
    DXP_Moves     = get_int("dxp-moves");
    DXP_Board     = get_bool("dxp-board");
    DXP_Search    = get_bool("dxp-search");
+
+   std::string var_str = get("variant");
+   if (var_str == "international") {
+      Variant = International;
+   } else if (var_str == "brazilian") {
+      Variant = Brazilian;
+   } else {
+      std::cerr << "unknown variant: " << var_str << std::endl;
+      std::exit(EXIT_FAILURE);
+   }
 }
 
 std::string get(const std::string & name) {

--- a/src/var.h
+++ b/src/var.h
@@ -12,6 +12,10 @@
 
 namespace var {
 
+// types
+enum variant_t { International, Brazilian };
+
+
 // variables
 
 extern bool Book;
@@ -30,6 +34,7 @@ extern int  DXP_Time;
 extern int  DXP_Moves;
 extern bool DXP_Board;
 extern bool DXP_Search;
+extern variant_t Variant;
 
 // functions
 


### PR DESCRIPTION
## Summary
- introduce `variant_t` in configuration for International vs Brazilian rules
- initialize board geometry dynamically with `pos_init_geometry`
- adapt modules to use variant-dependent square mappings

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_687408837d0883209335a254304394eb