### PR TITLE
Add Brazilian variant FEN support

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -17,6 +17,7 @@
 #include "move.h"
 #include "move_gen.h"
 #include "pos.h"
+#include "var.h"
 
 // constants
 
@@ -72,7 +73,7 @@ Board::Board() {
 
 void Board::init() {
 
-   board_from_fen(*this, Start_FEN);
+   board_from_fen(*this, var::Brazilian ? Start_FEN_Brazilian : Start_FEN);
 }
 
 void Board::copy(const Board & bd) {

--- a/src/fen.cpp
+++ b/src/fen.cpp
@@ -10,6 +10,7 @@
 #include "libmy.hpp"
 #include "pos.h"
 #include "util.h"
+#include "var.h"
 
 // prototypes
 
@@ -127,9 +128,13 @@ static void add_pieces(bit_t & bm, bit_t & bk, Scanner_Number & scan) {
 
 static void add_piece(bit_t & bm, bit_t & bk, int sq, bool king) {
 
-   assert(sq >= 1 && sq <= 50);
-
-   sq = square_from_50(sq - 1);
+   if (var::Brazilian) {
+      assert(sq >= 1 && sq <= 32);
+      sq = square_from_32(sq - 1);
+   } else {
+      assert(sq >= 1 && sq <= 50);
+      sq = square_from_50(sq - 1);
+   }
 
    if (king) {
       bit_set(bk, sq);
@@ -235,9 +240,11 @@ static std::string pos_pieces(const Pos & pos, int sd) {
    int run_sq = 0;
    int run_len = 0;
 
-   for (int i = 0; i < 50; i++) {
+   int limit = var::Brazilian ? 32 : 50;
 
-      int sq = square_from_50(i);
+   for (int i = 0; i < limit; i++) {
+
+      int sq = var::Brazilian ? square_from_32(i) : square_from_50(i);
       int pc = pos_square(pos, sq);
 
       if (pc == run_pc) {
@@ -277,7 +284,7 @@ static std::string run_string(int pc, int sq, int len) {
 
    assert(piece_is_ok(pc));
    assert(len != 0);
-   assert(sq + len <= 50);
+   assert(sq + len <= (var::Brazilian ? 32 : 50));
 
    std::string s;
 

--- a/src/fen.h
+++ b/src/fen.h
@@ -15,6 +15,7 @@ class Pos;
 // constants
 
 const std::string Start_FEN = "W:W31-50:B1-20";
+const std::string Start_FEN_Brazilian = "W:W21-32:B1-12";
 const std::string Start_Hub = "wbbbbbbbbbbbbbbbbbbbbeeeeeeeeeewwwwwwwwwwwwwwwwwwww";
 const std::string Start_DXP = "Wzzzzzzzzzzzzzzzzzzzzeeeeeeeeeewwwwwwwwwwwwwwwwwwww";
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -14,17 +14,18 @@
 #include "libmy.hpp"
 #include "move.h"
 #include "pos.h"
+#include "var.h"
 
 // functions
 
 void Game::clear() {
 
-   init(Start_FEN);
+   init(var::Brazilian ? Start_FEN_Brazilian : Start_FEN);
 }
 
 void Game::clear(int moves, double time, double inc) {
 
-   init(Start_FEN, moves, time, inc);
+   init(var::Brazilian ? Start_FEN_Brazilian : Start_FEN, moves, time, inc);
 }
 
 void Game::init(const std::string & fen) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -329,7 +329,7 @@ void Terminal::loop() {
 
    const Board & bd = game.board();
 
-   new_game();
+   new_game(var::Brazilian ? Start_FEN_Brazilian : Start_FEN);
 
    while (true) {
 
@@ -462,7 +462,7 @@ move_t Terminal::user_move() {
 
    } else if (command == "n") {
 
-      new_game();
+      new_game(var::Brazilian ? Start_FEN_Brazilian : Start_FEN);
 
    } else if (command == "q") {
 

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -47,6 +47,31 @@ const int Square_To_50[Square_Size] = {
      -1, -1, -1, -1, -1,
 };
 
+const int Square_From_32[32] = {
+   12, 13, 14, 15,
+   17, 18, 19, 20,
+   23, 24, 25, 26,
+   28, 29, 30, 31,
+   34, 35, 36, 37,
+   39, 40, 41, 42,
+   45, 46, 47, 48,
+   50, 51, 52, 53,
+};
+
+const int Square_To_32[Square_Size] = {
+   -1, -1, -1, -1, -1, -1,
+   -1, -1, -1, -1, -1, -1,
+    0,  1,  2,  3, -1,  4,
+    5,  6,  7, -1, -1,  8,
+    9, 10, 11, -1, 12, 13,
+   14, 15, -1, -1, 16, 17,
+   18, 19, -1, 20, 21, 22,
+   23, -1, -1, 24, 25, 26,
+   27, -1, 28, 29, 30, 31,
+   -1, -1, -1, -1, -1, -1,
+   -1, -1, -1, -1, -1, -1,
+};
+
 const int Square_File[Square_Size] = {
    -1, -1, -1, -1, -1, -1,
       1,  3,  5,  7,  9,
@@ -85,7 +110,11 @@ const int Inc[Dir_Size] = {
 
 std::string square_to_string(int sq) {
 
-   return ml::itos(square_to_50(sq) + 1);
+   if (var::Brazilian) {
+      return ml::itos(square_to_32(sq) + 1);
+   } else {
+      return ml::itos(square_to_50(sq) + 1);
+   }
 }
 
 bool string_is_square(const std::string & s) {
@@ -93,7 +122,11 @@ bool string_is_square(const std::string & s) {
    if (!string_is_nat(s)) return false;
 
    int sq = ml::stoi(s);
-   return sq >= 1 && sq <= 50;
+   if (var::Brazilian) {
+      return sq >= 1 && sq <= 32;
+   } else {
+      return sq >= 1 && sq <= 50;
+   }
 }
 
 int square_from_string(const std::string & s) {
@@ -104,8 +137,13 @@ int square_from_string(const std::string & s) {
 
 int square_from_int(int sq) {
 
-   if (sq < 1 || sq > 50) throw Bad_Input();
-   return square_from_50(sq - 1);
+   if (var::Brazilian) {
+      if (sq < 1 || sq > 32) throw Bad_Input();
+      return square_from_32(sq - 1);
+   } else {
+      if (sq < 1 || sq > 50) throw Bad_Input();
+      return square_from_50(sq - 1);
+   }
 }
 
 void Pos::copy(const Pos & pos) {
@@ -115,7 +153,7 @@ void Pos::copy(const Pos & pos) {
 
 void Pos::init() {
 
-   pos_from_fen(*this, Start_FEN);
+   pos_from_fen(*this, var::Brazilian ? Start_FEN_Brazilian : Start_FEN);
 }
 
 void Pos::init(int turn, bit_t wp, bit_t bp, bit_t k) {

--- a/src/pos.h
+++ b/src/pos.h
@@ -36,6 +36,8 @@ enum piece_t { WM, WK, BM, BK, Empty, Frame };
 
 extern const int Square_From_50[50];
 extern const int Square_To_50[Square_Size];
+extern const int Square_From_32[32];
+extern const int Square_To_32[Square_Size];
 
 extern const int Square_File[Square_Size];
 extern const int Square_Rank[Square_Size];
@@ -57,6 +59,8 @@ inline bool square_is_ok(int sq) {
 
 inline int square_from_50 (int sq) { return Square_From_50[sq]; }
 inline int square_to_50   (int sq) { return Square_To_50[sq]; }
+inline int square_from_32 (int sq) { return Square_From_32[sq]; }
+inline int square_to_32   (int sq) { return Square_To_32[sq]; }
 inline int square_file    (int sq) { return Square_File[sq]; }
 inline int square_rank    (int sq) { return Square_Rank[sq]; }
 inline int square_opp     (int sq) { return (Square_Size - 1) - sq; }

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -32,6 +32,7 @@ int  DXP_Time;
 int  DXP_Moves;
 bool DXP_Board;
 bool DXP_Search;
+bool Brazilian;
 
 static std::map<std::string, std::string> Var;
 
@@ -53,6 +54,7 @@ void init() {
    set("dxp-moves", "75");
    set("dxp-board", "false");
    set("dxp-search", "false");
+   set("brazilian", "false");
 
    update();
 }
@@ -108,6 +110,7 @@ void update() {
    DXP_Moves     = get_int("dxp-moves");
    DXP_Board     = get_bool("dxp-board");
    DXP_Search    = get_bool("dxp-search");
+   Brazilian     = get_bool("brazilian");
 }
 
 std::string get(const std::string & name) {

--- a/src/var.h
+++ b/src/var.h
@@ -30,6 +30,7 @@ extern int  DXP_Time;
 extern int  DXP_Moves;
 extern bool DXP_Board;
 extern bool DXP_Search;
+extern bool Brazilian;
 
 // functions
 


### PR DESCRIPTION
## Summary
- support Brazilian 32‑square FEN notation
- pick start position based on variant settings
- expose 32‑square mapping in position code

## Testing
- `make clean >/dev/null`
- `make >/tmp/make.log`
- `cat /tmp/make.log | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6874088491b08320a8333c745f5c4bd6