### PR TITLE
Add variant configuration option

### DIFF
--- a/scan.ini
+++ b/scan.ini
@@ -1,6 +1,7 @@
 
-book = true
+book = false
 book-margin = 2
+variant = brazilian
 threads = 1
 tt-size = 24
 bb-size = 4

--- a/src/var.cpp
+++ b/src/var.cpp
@@ -24,6 +24,7 @@ int  SMP_Threads;
 int  Trans_Size;
 bool BB;
 int  BB_Size;
+std::string Variant;
 bool DXP_Server;
 std::string DXP_Host;
 int  DXP_Port;
@@ -39,8 +40,9 @@ static std::map<std::string, std::string> Var;
 
 void init() {
 
-   set("book", "true");
+   set("book", "false");
    set("book-margin", "2");
+   set("variant", "brazilian");
    set("ponder", "false");
    set("threads", "1");
    set("tt-size", "24");
@@ -100,6 +102,7 @@ void update() {
    Trans_Size    = 1 << get_int("tt-size");
    BB_Size       = get_int("bb-size");
    BB            = BB_Size > 0;
+   Variant       = get("variant");
    DXP_Server    = get_bool("dxp-server");
    DXP_Host      = get("dxp-host");
    DXP_Port      = get_int("dxp-port");

--- a/src/var.h
+++ b/src/var.h
@@ -22,6 +22,7 @@ extern int  SMP_Threads;
 extern int  Trans_Size;
 extern bool BB;
 extern int  BB_Size;
+extern std::string Variant;
 extern bool DXP_Server;
 extern std::string DXP_Host;
 extern int  DXP_Port;


### PR DESCRIPTION
## Summary
- add `Variant` configuration variable
- set book default to false and add variant default `brazilian`
- expose new option in var parsing
- reflect defaults in `scan.ini`

## Testing
- `make -C src`

------
https://chatgpt.com/codex/tasks/task_e_6874088825748320bdfc381c7cf15637