### PR TITLE
Add basic test harness for FEN and move generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: all clean test
+
+all:
+	$(MAKE) -C src
+
+clean:
+	$(MAKE) -C src clean
+	$(MAKE) -C tests clean || true
+
+test: all
+	$(MAKE) -C tests test

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,30 @@
+CXX=g++
+CXXFLAGS=-std=c++11 -I../src
+LIBS=-lpthread -lm
+
+SRC_OBJS=../src/bb_base.o ../src/bb_comp.o ../src/bb_index.o ../src/bit.o \
+ ../src/board.o ../src/book.o ../src/dxp.o ../src/eval.o ../src/fen.o \
+ ../src/game.o ../src/hash.o ../src/libmy.o ../src/list.o ../src/move.o \
+ ../src/move_gen.o ../src/pos.o ../src/score.o ../src/search.o \
+ ../src/socket.o ../src/sort.o ../src/thread.o ../src/trans.o \
+ ../src/tuple.o ../src/util.o ../src/var.o
+
+TEST_OBJS=test_main.o board8.o
+TARGET=test_runner
+
+all: $(TARGET)
+
+$(TARGET): $(TEST_OBJS) $(SRC_OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LIBS)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+clean:
+	rm -f $(TEST_OBJS) $(TARGET)
+
+
+test: $(TARGET)
+	./$(TARGET)
+
+.PHONY: all clean test

--- a/tests/board8.cpp
+++ b/tests/board8.cpp
@@ -1,0 +1,108 @@
+#include "board8.h"
+#include <sstream>
+#include <cstring>
+#include <cstdlib>
+
+namespace board8 {
+
+static int idx_from_num(int n) {
+    int row = (n-1)/4;
+    int col = ((n-1)%4)*2 + ((row+1)%2);
+    return row*8 + col;
+}
+
+void init(Board& b) {
+    for(int i=0;i<64;i++) b.squares[i]=EMPTY;
+    b.turn=0;
+}
+
+static void add_piece(Board& b,bool white,bool king,int num) {
+    int idx=idx_from_num(num);
+    if(white) b.squares[idx]= king?WK:WM; else b.squares[idx]= king?BK:BM;
+}
+
+static void parse_side(Board& b,const std::string& part,bool white) {
+    std::stringstream ss(part);
+    std::string token;
+    while(std::getline(ss, token, ',')) {
+        if(token.empty()) continue;
+        bool king=false;
+        if(token[0]=='K') { king=true; token=token.substr(1); }
+        size_t dash = token.find('-');
+        if(dash==std::string::npos) {
+            int num=std::atoi(token.c_str());
+            add_piece(b,white,king,num);
+        } else {
+            int from=std::atoi(token.substr(0,dash).c_str());
+            int to=std::atoi(token.substr(dash+1).c_str());
+            for(int n=from;n<=to;n++) add_piece(b,white,king,n);
+        }
+    }
+}
+
+void from_fen(Board& b,const std::string& fen) {
+    init(b);
+    size_t pos=0;
+    b.turn = (fen[pos]=='W')?0:1;
+    size_t w = fen.find(":W");
+    size_t bpos = fen.find(":B", w+2);
+    std::string wpart = fen.substr(w+2, bpos-(w+2));
+    std::string bpart = fen.substr(bpos+2);
+    parse_side(b,wpart,true);
+    parse_side(b,bpart,false);
+}
+
+static bool on_board(int r,int c){ return r>=0 && r<8 && c>=0 && c<8; }
+
+std::vector<std::pair<int,int>> gen_moves(const Board& b) {
+    std::vector<std::pair<int,int>> moves;
+    int sd=b.turn;
+    int dir = sd==0?-1:1; // white moves up (-1)
+    bool must=false;
+    for(int idx=0; idx<64; idx++) {
+        Piece pc=b.squares[idx];
+        if((sd==0 && (pc==WM||pc==WK)) || (sd==1 && (pc==BM||pc==BK))) {
+            int r=idx/8,c=idx%8;
+            int dirs[4][2]={{dir,-1},{dir,1},{-dir,-1},{-dir,1}};
+            for(int k=0;k<4;k++) {
+                if(pc!=WK && pc!=BK && k>=2) break; // men only forward
+                int nr=r+dirs[k][0];
+                int nc=c+dirs[k][1];
+                if(!on_board(nr,nc)) continue;
+                int nidx=nr*8+nc;
+                if(b.squares[nidx]==EMPTY) {
+                    if(!must) moves.push_back({idx,nidx});
+                } else {
+                    int jr=nr+dirs[k][0];
+                    int jc=nc+dirs[k][1];
+                    if(on_board(jr,jc)) {
+                        int jidx=jr*8+jc;
+                        Piece op=b.squares[nidx];
+                        if(((sd==0 && (op==BM||op==BK))||(sd==1 && (op==WM||op==WK))) && b.squares[jidx]==EMPTY) {
+                            if(!must) { moves.clear(); must=true; }
+                            moves.push_back({idx,jidx});
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return moves;
+}
+
+int evaluate(const Board& b) {
+    int w=0,bk=0;
+    for(int i=0;i<64;i++) {
+        switch(b.squares[i]) {
+            case WM: w+=100; break;
+            case WK: w+=175; break;
+            case BM: bk-=100; break;
+            case BK: bk-=175; break;
+            default: break;
+        }
+    }
+    return w+bk;
+}
+
+} // namespace board8
+

--- a/tests/board8.h
+++ b/tests/board8.h
@@ -1,0 +1,21 @@
+#ifndef BOARD8_H
+#define BOARD8_H
+#include <string>
+#include <vector>
+
+namespace board8 {
+
+enum Piece { EMPTY=0, WM, WK, BM, BK };
+struct Board {
+    Piece squares[64];
+    int turn; // 0=white 1=black
+};
+
+void init(Board& b);
+void from_fen(Board& b, const std::string& fen);
+int evaluate(const Board& b);
+std::vector<std::pair<int,int>> gen_moves(const Board& b);
+
+} // namespace board8
+
+#endif

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,63 @@
+#include "board.h"
+#include "fen.h"
+#include "move_gen.h"
+#include "list.h"
+#include "board8.h"
+#include <iostream>
+#include <vector>
+#include <string>
+
+#define ASSERT_TRUE(cond) do { if(!(cond)) { std::cerr << "FAIL:" << __FILE__ << ":" << __LINE__ << " " << #cond << std::endl; return false; } } while(0)
+
+bool test_fen10() {
+    Board bd;
+    board_from_fen(bd, Start_FEN);
+    std::string s = pos_fen(bd);
+    ASSERT_TRUE(s == Start_FEN);
+    return true;
+}
+
+bool test_movegen10() {
+    Board bd;
+    board_from_fen(bd, Start_FEN);
+    List list;
+    gen_moves(list, bd);
+    ASSERT_TRUE(list.size() == 9);
+    return true;
+}
+
+bool test_fen8() {
+    board8::Board bd;
+    board8::from_fen(bd, "W:W21-32:B1-12");
+    ASSERT_TRUE(bd.turn == 0);
+    return true;
+}
+
+bool test_movegen8() {
+    board8::Board bd;
+    board8::from_fen(bd, "W:W21-32:B1-12");
+    auto mv = board8::gen_moves(bd);
+    ASSERT_TRUE(mv.size() == 7);
+    return true;
+}
+
+bool test_eval8() {
+    board8::Board bd;
+    board8::from_fen(bd, "W:W22:B11");
+    int sc = board8::evaluate(bd);
+    ASSERT_TRUE(sc == 0);
+    return true;
+}
+
+int main() {
+    int fails=0;
+    if(!test_fen10()) fails++;
+    if(!test_movegen10()) fails++;
+    if(!test_fen8()) fails++;
+    if(!test_movegen8()) fails++;
+    if(!test_eval8()) fails++;
+    if(fails==0) std::cout << "All tests passed" << std::endl;
+    else std::cout << fails << " tests failed" << std::endl;
+    return fails;
+}
+


### PR DESCRIPTION
## Summary
- add simple root Makefile with `make test`
- implement minimal 8x8 board module for tests
- add unit tests covering FEN round trips, move generation and evaluation
- provide Makefile to build and run tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6874088a86908320896ed78510ac7383